### PR TITLE
add gsettings overrides only for ubuntu

### DIFF
--- a/debian/vala-panel-appmenu/debian/budgie-appmenu-applet.gsettings-override
+++ b/debian/vala-panel-appmenu/debian/budgie-appmenu-applet.gsettings-override
@@ -1,0 +1,2 @@
+[com.canonical.unity-gtk-module]
+blacklist=["acroread","emacs","emacs23","emacs23-lucid","emacs24","emacs24-lucid","budgie-panel"]

--- a/debian/vala-panel-appmenu/debian/mate-applet-appmenu.gsettings-override
+++ b/debian/vala-panel-appmenu/debian/mate-applet-appmenu.gsettings-override
@@ -1,0 +1,2 @@
+[com.canonical.unity-gtk-module]
+blacklist=["acroread","emacs","emacs23","emacs23-lucid","emacs24","emacs24-lucid","mate-panel"]

--- a/debian/vala-panel-appmenu/debian/mate-applet-appmenu.install
+++ b/debian/vala-panel-appmenu/debian/mate-applet-appmenu.install
@@ -1,3 +1,3 @@
-usr/lib/*/mate-panel
+usr/lib/mate-panel
 usr/share/dbus-1/services/*
 usr/share/mate-panel

--- a/debian/vala-panel-appmenu/debian/rules
+++ b/debian/vala-panel-appmenu/debian/rules
@@ -25,12 +25,19 @@ override_dh_auto_configure:
 		-DENABLE_BUDGIE=ON \
 		-DENABLE_MATE=ON \
 		-DENABLE_VALAPANEL=OFF \
-		-DENABLE_XFCE=ON
+		-DENABLE_XFCE=ON \
+		-DCMAKE_INSTALL_LIBEXECDIR=/usr/lib
 
 override_dh_auto_install:
 	dh_auto_install
 	mkdir -p $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/appmenu-budgie
 	mv $(CURDIR)/debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/budgie-desktop/plugins/* $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/appmenu-budgie
+	mv $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/libappmenu-budgie.so $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/appmenu-budgie
+
+override_dh_installgsettings:
+ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo ubuntu),ubuntu)
+	dh_installgsettings --priority=15
+endif
 
 override_dh_strip:
 	dh_strip --package=budgie-appmenu-applet


### PR DESCRIPTION
ok - number of issues resolved in this PR

1. MATE did not compile  - the installation folder format in mate's debian .install file was looking for a non existent multiarch folder.

2. Added LIBEXEC stuff - this only installs the .so file in the right folder - the .plugin is still in a multiarch location.  So fixed that in a modified rules for budgie

3. Added gsettings_overrides for both MATE and Budgie using the values in the main.c blacklist.  This only installs for Ubuntu (rules change)

This has been built and tested on Ubuntu 17.04 - here https://launchpad.net/~ubuntubudgie-dev/+archive/ubuntu/global-menu-test