### PR TITLE
Bump vala-panel-appmenu version to 0.4.4. Fix build failures.

### DIFF
--- a/debian/vala-panel-appmenu/debian/changelog
+++ b/debian/vala-panel-appmenu/debian/changelog
@@ -1,3 +1,9 @@
+vala-panel-appmenu (0.4.4-1) artful; urgency=medium
+
+  * New upstream release.
+
+ -- Martin Wimpress <code@flexion.org>  Sun, 14 May 2017 21:35:13 +0100
+
 vala-panel-appmenu (0.4.3-1) artful; urgency=medium
 
   * New upstream release.

--- a/debian/vala-panel-appmenu/debian/mate-applet-appmenu.install
+++ b/debian/vala-panel-appmenu/debian/mate-applet-appmenu.install
@@ -1,3 +1,3 @@
-usr/lib/mate-panel
+usr/lib/*/mate-panel
 usr/share/dbus-1/services/*
 usr/share/mate-panel

--- a/debian/vala-panel-appmenu/debian/rules
+++ b/debian/vala-panel-appmenu/debian/rules
@@ -32,7 +32,6 @@ override_dh_auto_install:
 	dh_auto_install
 	mkdir -p $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/appmenu-budgie
 	mv $(CURDIR)/debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/budgie-desktop/plugins/* $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/appmenu-budgie
-	mv $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/libappmenu-budgie.so $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/appmenu-budgie
 
 override_dh_installgsettings:
 ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo ubuntu),ubuntu)


### PR DESCRIPTION
This pull requests bumps the version to 0.4.4 and corrects a couple of changes that introduced build failures when submitting for a clean build on a PPA.