### PR TITLE
vala-panel-appmenu: Bump to 0.5.2

### DIFF
--- a/debian/vala-panel-appmenu/debian/99vala-panel-appmenu
+++ b/debian/vala-panel-appmenu/debian/99vala-panel-appmenu
@@ -7,4 +7,3 @@ else
 fi
 export GTK_MODULES
 export UBUNTU_MENUPROXY=1
-export APPMENU_DISPLAY_BOTH=1

--- a/debian/vala-panel-appmenu/debian/99vala-panel-appmenu
+++ b/debian/vala-panel-appmenu/debian/99vala-panel-appmenu
@@ -7,3 +7,4 @@ else
 fi
 export GTK_MODULES
 export UBUNTU_MENUPROXY=1
+export APPMENU_DISPLAY_BOTH=1

--- a/debian/vala-panel-appmenu/debian/changelog
+++ b/debian/vala-panel-appmenu/debian/changelog
@@ -1,3 +1,9 @@
+vala-panel-appmenu (0.5.2-1) artful; urgency=medium
+
+  * New upstream release.
+
+ -- Martin Wimpress <code@flexion.org>  Sat, 10 Jun 2017 13:20:46 +0100
+
 vala-panel-appmenu (0.5.1-1) artful; urgency=medium
 
   * New upstream release.

--- a/debian/vala-panel-appmenu/debian/changelog
+++ b/debian/vala-panel-appmenu/debian/changelog
@@ -1,10 +1,3 @@
-vala-panel-appmenu (0.5.2-2) artful; urgency=medium
-
-  * debian/99vala-panel-appmenu: Add 'export APPMENU_DISPLAY_BOTH=1' to
-    make sure GTK2 applications work.
-
- -- Martin Wimpress <code@flexion.org>  Sun, 11 Jun 2017 22:26:08 +0100
-
 vala-panel-appmenu (0.5.2-1) artful; urgency=medium
 
   * New upstream release.

--- a/debian/vala-panel-appmenu/debian/changelog
+++ b/debian/vala-panel-appmenu/debian/changelog
@@ -1,3 +1,10 @@
+vala-panel-appmenu (0.5.2-2) artful; urgency=medium
+
+  * debian/99vala-panel-appmenu: Add 'export APPMENU_DISPLAY_BOTH=1' to
+    make sure GTK2 applications work.
+
+ -- Martin Wimpress <code@flexion.org>  Sun, 11 Jun 2017 22:26:08 +0100
+
 vala-panel-appmenu (0.5.2-1) artful; urgency=medium
 
   * New upstream release.

--- a/debian/vala-panel-appmenu/debian/copyright
+++ b/debian/vala-panel-appmenu/debian/copyright
@@ -2,14 +2,37 @@ Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: vala-panel-appmenu
 Source: <https://github.com/rilian-la-te/vala-panel-appmenu>
 
-Files: *
-Copyright: 2014-2017 <Konstantin P. <ria.freelander@gmail.com>
+Files: jayatana/*
+Copyright: 2014 Jared Gonzalez
+License: Expat
+
+Files: unity-gtk-module/*
+Copyright: 2012 Canonical Ltd.
+License: LGPL-3.0+
+
+Files: cmake/*
+       dbusmenu/*
+       vapi/*
+       lib/*
+Copyright: 2014-2017 <Konstantin Pugin <ria.freelander@gmail.com>
 License: LGPL-3.0+
 
 Files: debian/*
-Copyright: 2015-2017 Konstantin P. <ria.freelander@gmail.com>
+Copyright: 2015-2017 Konstantin Pugin <ria.freelander@gmail.com>
            2017 Martin Wimpress <martin.wimpress@ubuntu.com>
 License: LGPL-3.0+
+
+Files: .clang-format
+       CMakeLists.txt
+       CMakeLists.txt.user
+       data/*
+       rpm/*
+       po/*
+       README.md
+Copyright: *No copyright*
+License: LGPL-3.0+ or Expat
+Comment:
+ Appropriately apply licenses as found in LICENSE
 
 License: LGPL-3.0+
  This package is free software; you can redistribute it and/or
@@ -27,3 +50,23 @@ License: LGPL-3.0+
  .
  On Debian systems, the complete text of the GNU Lesser General
  Public License can be found in "/usr/share/common-licenses/LGPL-3".
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+ .
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/debian/vala-panel-appmenu/debian/rules
+++ b/debian/vala-panel-appmenu/debian/rules
@@ -32,8 +32,6 @@ override_dh_auto_install:
 	dh_auto_install
 	mkdir -p $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/appmenu-budgie
 	mv $(CURDIR)/debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/budgie-desktop/plugins/* $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/appmenu-budgie
-	#mkdir -p $(CURDIR)/debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/mate-panel
-	#mv $(CURDIR)/debian/tmp/usr/lib/mate-panel/appmenu-mate $(CURDIR)/debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/mate-panel/
 
 override_dh_installgsettings:
 ifeq ($(shell dpkg-vendor --derives-from Ubuntu && echo ubuntu),ubuntu)

--- a/debian/vala-panel/debian/copyright
+++ b/debian/vala-panel/debian/copyright
@@ -2,15 +2,59 @@ Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: vala-panel
 Source: <https://github.com/rilian-la-te/vala-panel>
 
-Files: *
+Files: app/*
+       applets/*
+       cmake/*
+       lib/*
+       runner/*
+       vapi/*
 Copyright: 2014-2017 <Konstantin P. <ria.freelander@gmail.com>
-           2006-2014 <LXDE Developers>
+License: LGPL-3.0+
+
+Files: applets/wnck/icontasks/*
+Copyright: 2014-2016 Ikey Doherty <ikey@solus-project.com>
+License: LGPL-3.0+
+
+Files: applets/wnck/tasklist-xfce/tasklist-widget.c
+       applets/wnck/tasklist-xfce/tasklist-widget.h
+Copyright: 2008-2010 Nick Schermer <nick@xfce.org>
+License: LGPL-3.0+
+
+Files: applets/wnck/tasklist-xfce/xfce-arrow-button.c
+       applets/wnck/tasklist-xfce/xfce-arrow-button.h
+Copyright: 2006-2007 Jasper Huijsmans <jasper@xfce.org>
+           2008-2010 Nick Schermer <nick@xfce.org>
+License: LGPL-3.0+
+
+Files: applets/wnck/xembed/xembed-ccode.c
+       applets/wnck/xembed/xembed-ccode.h
+Copyright: 2008-2014 LxDE Developers
+License: LGPL-3.0+
+
+Files: lib/guuid.c
+       lib/guuid.c
+Copyright: 2013-2015, 2017 Red Hat, Inc.
 License: LGPL-3.0+
 
 Files: debian/*
 Copyright: 2015-2017 Konstantin P. <ria.freelander@gmail.com>
            2017 Martin Wimpress <martin.wimpress@ubuntu.com>
 License: LGPL-3.0+
+
+Files: .clang-format
+       .configure-custom.sh
+       configure
+       vala-panel.pc.cmake
+       CMakeLists.txt
+       CMakeLists.txt.user
+       data/*
+       rpm/*
+       po/*
+       README.md
+Copyright: *No copyright*
+License: LGPL-3.0+
+Comment:
+ Appropriately apply licenses as found in LICENSE
 
 License: LGPL-3.0+
  This package is free software; you can redistribute it and/or


### PR DESCRIPTION
Bump to 0.5.2 and drop obsolete rules for `mate-aplet-appmenu`.