### PR TITLE
correct budgie library install location for the debian package

### DIFF
--- a/debian/vala-panel-appmenu/debian/budgie-appmenu-applet.install
+++ b/debian/vala-panel-appmenu/debian/budgie-appmenu-applet.install
@@ -1,1 +1,1 @@
-usr/lib/budgie-desktop/plugins/
+usr/lib/budgie-desktop

--- a/debian/vala-panel-appmenu/debian/rules
+++ b/debian/vala-panel-appmenu/debian/rules
@@ -31,6 +31,7 @@ override_dh_auto_configure:
 override_dh_auto_install:
 	dh_auto_install
 	mkdir -p $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/appmenu-budgie
+	mv $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/libappmenu-budgie.so $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/appmenu-budgie
 	mv $(CURDIR)/debian/tmp/usr/lib/$(DEB_HOST_MULTIARCH)/budgie-desktop/plugins/* $(CURDIR)/debian/tmp/usr/lib/budgie-desktop/plugins/appmenu-budgie
 
 override_dh_installgsettings:


### PR DESCRIPTION
The latest changes in the appmenu project has resulted in the binary for budgie being created in the budgie-desktop plugins folder.  For libpeas - the library and .plugin needs to be in the same folder.

The PR fixes this specifically for debian budgie-desktop