### PR TITLE
add override so that budgie desktop does not freeze #116

### DIFF
--- a/debian/vala-panel-appmenu/debian/budgie-appmenu-applet.gsettings-override
+++ b/debian/vala-panel-appmenu/debian/budgie-appmenu-applet.gsettings-override
@@ -1,0 +1,2 @@
+[com.canonical.unity-gtk-module]
+blacklist=["acroread","emacs","emacs23","emacs23-lucid","emacs24","emacs24-lucid","budgie-panel"]


### PR DESCRIPTION
as previously discussed, the debian package needs an override for budgie desktop

n.b. this only adds the override for the binary package budgie-appmenu-applet and does not affect other binary packages.

As an aside I note there are quite a few commits since v0.5.2.  These commits will break the budgie-appmenu-applet package.  I am happy to fix the package - just ping me when you next do a point release (e.g. 0.5.3) with the latest master commits in the appmenu project.