### PR TITLE
add override specific for budgie-desktop

### DIFF
--- a/debian/vala-panel-appmenu/debian/10_budgie_appmenu_applet.gschema.override
+++ b/debian/vala-panel-appmenu/debian/10_budgie_appmenu_applet.gschema.override
@@ -1,0 +1,2 @@
+[com.canonical.unity-gtk-module:budgie-desktop]
+blacklist=["acroread","emacs","emacs23","emacs23-lucid","emacs24","emacs24-lucid","budgie-panel"]


### PR DESCRIPTION
This is a follow on from #19 

After further discussion with @flexiondotorg we noted that the new libglib available in debian unstable/ubuntu 17.10 now has a useful feature to allow all desktops to override a specific key without trampling over each-other

This PR is similar to #19 but with ":budgie-desktop" appended - this is specific to budgie desktop.