### PR TITLE
Install gschema overrides for Budgie and MATE

### DIFF
--- a/debian/vala-panel-appmenu/debian/10_mate_applet_appmenu.gschema.override
+++ b/debian/vala-panel-appmenu/debian/10_mate_applet_appmenu.gschema.override
@@ -1,0 +1,2 @@
+[com.canonical.unity-gtk-module:MATE]
+blacklist=['mate-menu','mate-panel','mate-indicator-applet','mate-indicator-applet-appmenu','mate-indicator-applet-complete']

--- a/debian/vala-panel-appmenu/debian/budgie-appmenu-applet.install
+++ b/debian/vala-panel-appmenu/debian/budgie-appmenu-applet.install
@@ -1,1 +1,2 @@
+debian/10_budgie_appmenu_applet.gschema.override usr/share/glib-2.0/schemas/
 usr/lib/budgie-desktop

--- a/debian/vala-panel-appmenu/debian/changelog
+++ b/debian/vala-panel-appmenu/debian/changelog
@@ -1,3 +1,10 @@
+vala-panel-appmenu (0.5.3-0ubuntu2) artful; urgency=medium
+
+  * Add gschema overrides to add the appropriate unity-gtk-module
+    blacklist for Budgie and MATE. (LP: #1705653)
+
+ -- Martin Wimpress <martin.wimpress@ubuntu.com>  Wed, 30 Aug 2017 11:08:34 +0100
+
 vala-panel-appmenu (0.5.3-0ubuntu1) artful; urgency=medium
 
   * New upstream release.

--- a/debian/vala-panel-appmenu/debian/mate-applet-appmenu.install
+++ b/debian/vala-panel-appmenu/debian/mate-applet-appmenu.install
@@ -1,3 +1,4 @@
+debian/10_mate_applet_appmenu.gschema.override usr/share/glib-2.0/schemas/
 usr/lib/mate-panel/*
 usr/share/dbus-1/services/*
 usr/share/mate-panel


### PR DESCRIPTION
vala-panel-appmenu 0.5.3-0ubuntu2 has been uploaded to Ubuntu, the only change is including desktop specific gschema overrides for Budgie and MATE.